### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 MCP server for Devin AI with Slack integration
 
+<a href="https://glama.ai/mcp/servers/@kazuph/mcp-devin">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kazuph/mcp-devin/badge" alt="MCP-Devin MCP server" />
+</a>
+
 This is a TypeScript-based MCP server that provides integration between Devin AI and Slack. The server enables:
 
 - Creating Devin sessions and automatically posting tasks to Slack


### PR DESCRIPTION
This PR adds a badge for the [MCP-Devin](https://glama.ai/mcp/servers/@kazuph/mcp-devin) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@kazuph/mcp-devin">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kazuph/mcp-devin/badge" alt="MCP-Devin MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.